### PR TITLE
Add Supabase health check + secure seeder (fix 404) and env-aware client

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,25 @@ npm run dev
 Le middleware redirige par défaut vers `/fr`.
 npm run dev
 
+## Dev checks (health & seed)
+
+1. Démarrer le dev
+
+```bash
+nvm use 20 || true
+npm install
+npm run dev
+```
+
+2. Santé Supabase
+
+```bash
+curl -s http://localhost:3000/api/health/supabase | jq .
+```
+
+3. Seed sécurisé (nécessite SUPABASE_SERVICE_ROLE_KEY et SEED_TOKEN)
+
+```bash
+curl -X POST -H "x-seed-token: $SEED_TOKEN" http://localhost:3000/api/dev/seed
+```
+

--- a/src/app/api/dev/seed/route.ts
+++ b/src/app/api/dev/seed/route.ts
@@ -1,0 +1,60 @@
+import {NextResponse} from 'next/server';
+import {createClient} from '@supabase/supabase-js';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: Request) {
+  const token = req.headers.get('x-seed-token');
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return NextResponse.json({ ok: false, error: 'Missing SUPABASE env (URL or SERVICE_ROLE_KEY)' }, { status: 400 });
+  }
+  if (!process.env.SEED_TOKEN) {
+    return NextResponse.json({ ok: false, error: 'Missing SEED_TOKEN' }, { status: 400 });
+  }
+  if (token !== process.env.SEED_TOKEN) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized seed token' }, { status: 401 });
+  }
+
+  const admin = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!, { auth: { persistSession: false } });
+  const now = new Date().toISOString();
+  const up = async (table: string, rows: any[], conflict?: string) => {
+    const { error } = await admin.from(table).upsert(rows, { onConflict: conflict });
+    if (error) throw new Error(`${table}: ${error.message}`);
+  };
+
+  try {
+    await up('locales', [
+      { code: 'fr', name: 'Français', dir: 'ltr' },
+      { code: 'en', name: 'English', dir: 'ltr' },
+      { code: 'ar', name: 'العربية', dir: 'rtl' }
+    ], 'code');
+
+    await up('categories', [{ slug: 'sous-vetements', created_at: now, updated_at: now }], 'slug');
+    const { data: cat } = await admin.from('categories').select('id').eq('slug','sous-vetements').maybeSingle();
+    if (!cat?.id) throw new Error('Category sous-vetements not created');
+
+    await up('category_translations', [
+      { category_id: cat.id, locale: 'fr', name: 'Sous-vêtements', description: 'Confort & pudeur' },
+      { category_id: cat.id, locale: 'en', name: 'Underwear', description: 'Comfort & modesty' },
+      { category_id: cat.id, locale: 'ar', name: 'الملابس الداخلية', description: 'راحة وحشمة' }
+    ], 'category_id,locale');
+
+    await up('products', [{ sku: 'LUBNA-UW-SET-001', category_id: cat.id, price_cents: 3999, currency: 'EUR', status: 'active', created_at: now, updated_at: now }], 'sku');
+    const { data: prod } = await admin.from('products').select('id').eq('sku','LUBNA-UW-SET-001').maybeSingle();
+    if (!prod?.id) throw new Error('Product not created');
+
+    await up('product_translations', [
+      { product_id: prod.id, locale: 'fr', name: 'Ensemble Confort Rose', subtitle: 'Respirant & doux', description: 'Parfait au quotidien' },
+      { product_id: prod.id, locale: 'en', name: 'Pink Comfort Set', subtitle: 'Breathable & soft', description: 'Perfect for daily wear' },
+      { product_id: prod.id, locale: 'ar', name: 'طقم وردي مريح', subtitle: 'قابل للتنفس وناعم', description: 'مثالي للاستخدام اليومي' }
+    ], 'product_id,locale');
+
+    await up('product_media', [
+      { product_id: prod.id, variant_id: null, storage_path: 'https://epefjqrxjbpcasygwywh.supabase.co/storage/v1/object/public/assets-public/hero1.png', alt: 'Ensemble rose', position: 0 }
+    ]);
+
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: String(e?.message || e) }, { status: 500 });
+  }
+}

--- a/src/app/api/health/supabase/route.ts
+++ b/src/app/api/health/supabase/route.ts
@@ -1,0 +1,28 @@
+import {NextResponse} from 'next/server';
+import {supabase, hasEnv} from '@/lib/supabase';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const env = { url: hasEnv.url, anon: hasEnv.anon, service: hasEnv.service };
+  if (!supabase) {
+    return NextResponse.json({ configured: false, env, error: 'Missing NEXT_PUBLIC_SUPABASE_URL and/or NEXT_PUBLIC_SUPABASE_ANON_KEY' }, { status: 200 });
+  }
+
+  const results: Record<string, any> = {};
+  const tryQuery = async (label: string, q: () => Promise<any>) => {
+    try {
+      const { data, error } = await q();
+      if (error) results[label] = { error: error.message };
+      else results[label] = { count: Array.isArray(data) ? data.length : (data?.length ?? null) };
+    } catch (e: any) {
+      results[label] = { error: String(e?.message || e) };
+    }
+  };
+
+  await tryQuery('products_active', () => supabase!.from('products').select('id').eq('status','active'));
+  await tryQuery('product_translations', () => supabase!.from('product_translations').select('id'));
+  await tryQuery('resources_published', () => supabase!.from('resources').select('id').eq('status','published'));
+
+  return NextResponse.json({ configured: true, env, results }, { status: 200 });
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,16 @@
+import {createClient} from '@supabase/supabase-js';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+const service = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+export const hasEnv = { url: !!url, anon: !!anon, service: !!service };
+
+export const supabase = (hasEnv.url && hasEnv.anon)
+  ? createClient(url, anon, { auth: { persistSession: false } })
+  : null;
+
+export const supabaseAdmin = (hasEnv.url && hasEnv.service)
+  ? createClient(url, service, { auth: { persistSession: false } })
+  : null;
+


### PR DESCRIPTION
## Summary
- add env-aware Supabase client and admin helper
- implement Supabase health check route
- provide secure seeding API and docs

## Testing
- `nvm use 20 || true`
- `npm install --silent`
- `npm run dev --silent & echo $! > .pid && sleep 6`
- `curl -s http://localhost:3000/api/health/supabase`
- `curl -s -X POST -H 'x-seed-token: dev-seed-ok' http://localhost:3000/api/dev/seed`
- `test -f .pid && kill $(cat .pid) 2>/dev/null || true; rm -f .pid`


------
https://chatgpt.com/codex/tasks/task_e_68c40edb3440832c91732a7c8dd124ec