### PR TITLE
Add /api/ping and ensure middleware excludes API

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,12 @@
 import createMiddleware from 'next-intl/middleware';
-import intlConfig from './next-intl.config';
 
 export default createMiddleware({
-  locales: intlConfig.locales,
-  defaultLocale: intlConfig.defaultLocale,
-  localePrefix: intlConfig.localePrefix
+  locales: ['fr', 'en', 'ar'],
+  defaultLocale: 'fr',
+  localePrefix: 'always'
 });
 
+// Ne pas intercepter les routes /api ni /_next, ni fichiers statiques
 export const config = {
   matcher: ['/((?!api|_next|.*\\..*).*)']
 };

--- a/src/app/api/ping/route.ts
+++ b/src/app/api/ping/route.ts
@@ -1,0 +1,5 @@
+import {NextResponse} from 'next/server';
+export const dynamic = 'force-dynamic';
+export async function GET() {
+  return NextResponse.json({ ok: true, time: new Date().toISOString() });
+}


### PR DESCRIPTION
## Summary
- update middleware to configure locales directly and ignore API and static routes
- add /api/ping endpoint for health checks

## Testing
- `nvm use 20 || true`
- `npm install --silent`
- `npm run dev --silent & echo $! > .pid && sleep 5`
- `echo '--- PING ---'`
- `curl -s http://localhost:3000/api/ping || curl -s http://localhost:3001/api/ping`
- `test -f .pid && kill $(cat .pid) 2>/dev/null || true; rm -f .pid`

------
https://chatgpt.com/codex/tasks/task_e_68c41550fc8c832c8a5b5b6b76ad0967