### PR TITLE
Dev slides panel + hardened seed & preview endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,31 @@ curl -s -X POST -H "x-admin-token: $ADMIN_TOKEN" http://localhost:3001/api/dev/s
 curl -s "$NEXT_PUBLIC_SUPABASE_URL/storage/v1/object/public/assets-public/home-slides/manifest.json" | jq .
 ```
 
-### UI dev
-Ouvre `http://localhost:3001/fr/dev/slides` et colle le token.
+### Slides Dev Panel
+
+Run on port 3001 and open the locale page:
+
+```bash
+pkill -f "next dev" 2>/dev/null || true
+npm run -s dev:3001 & echo $! > .pid && sleep 5
+open http://localhost:3001/fr/dev/slides # or /en/dev/slides, /ar/dev/slides
+```
+
+Seed with a token (matches `ADMIN_TOKEN` or `SEED_TOKEN` in `.env.local`):
+
+```bash
+curl -s -X POST -H "x-admin-token: $ADMIN_TOKEN" http://localhost:3001/api/dev/seed-slides
+# or
+curl -s -X POST -H "x-seed-token: $SEED_TOKEN"  http://localhost:3001/api/dev/seed-slides
+```
+
+Probe public manifest (should be 200 OK after seeding & bucket public):
+
+```bash
+curl -I "${NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/assets-public/home-slides/manifest.json" | head -n 5
+```
+
+> **Production safety**: `/api/dev/*` routes return 404 in production.
 
 ## Démarrer
 

--- a/src/app/[locale]/dev/slides/page.tsx
+++ b/src/app/[locale]/dev/slides/page.tsx
@@ -1,24 +1,86 @@
 'use client';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-export default function SlidesDev() {
-  const [token, setToken] = useState('');
-  const [out, setOut] = useState('');
+export default function DevSlidesPage() {
+  const [token, setToken] = useState<string>('');
+  const [busy, setBusy] = useState(false);
+  const [debug, setDebug] = useState<any>(null);
+  const [slides, setSlides] = useState<any[]>([]);
+  const [probe, setProbe] = useState<{url?: string; status?: number; ok?: boolean} | null>(null);
 
-  async function seed() {
-    setOut('Seeding…');
-    const res = await fetch('/api/dev/seed-slides', { method: 'POST', headers: { 'x-admin-token': token } });
-    const json = await res.json().catch(() => ({}));
-    setOut(JSON.stringify(json, null, 2));
+  const manifestURL = useMemo(() => {
+    const base = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+    if (!base) return '';
+    try {
+      return new URL('storage/v1/object/public/assets-public/home-slides/manifest.json', base).toString();
+    } catch {
+      return '';
+    }
+  }, []);
+
+  useEffect(() => {
+    // prefill from env-like hint via server debug (no secrets are exposed)
+    fetch('/api/dev/debug').then(r => r.ok ? r.json() : null).then(j => setDebug(j)).catch(() => {});
+    fetch('/api/dev/slides').then(r => r.ok ? r.json() : null).then(j => setSlides(j?.slides || [])).catch(() => {});
+  }, []);
+
+  async function seed(kind: 'admin' | 'seed') {
+    setBusy(true);
+    try {
+      const headerName = kind === 'admin' ? 'x-admin-token' : 'x-seed-token';
+      const res = await fetch('/api/dev/seed-slides', { method: 'POST', headers: token ? { [headerName]: token } as any : undefined });
+      const j = await res.json().catch(() => ({}));
+      alert(res.ok ? `Seed OK: ${j?.publicManifestURL || ''}` : `Seed ERROR: ${j?.error || res.status}`);
+      // refresh
+      const s = await fetch('/api/dev/slides').then(r => r.json());
+      setSlides(s?.slides || []);
+    } finally { setBusy(false); }
+  }
+
+  async function probePublic() {
+    if (!manifestURL) return;
+    try {
+      const res = await fetch(manifestURL, { cache: 'no-store' });
+      setProbe({ url: manifestURL, status: res.status, ok: res.ok });
+    } catch {
+      setProbe({ url: manifestURL, status: 0, ok: false });
+    }
   }
 
   return (
-    <main className="p-6 max-w-xl mx-auto space-y-4">
-      <h1 className="text-2xl font-semibold">Slides – Dev</h1>
-      <p className="text-sm opacity-80">Colle ton token (ADMIN_TOKEN ou SEED_TOKEN), puis clique pour uploader le manifest.</p>
-      <input className="border px-2 py-1 w-full rounded" placeholder="x-admin-token" value={token} onChange={(e)=>setToken(e.target.value)} />
-      <button className="px-3 py-1.5 rounded bg-black text-white" onClick={seed}>Seed manifest</button>
-      <pre className="text-xs bg-neutral-100 dark:bg-neutral-900 p-3 rounded whitespace-pre-wrap">{out}</pre>
-    </main>
+    <div className="p-6 max-w-4xl mx-auto space-y-6">
+      <h1 className="text-2xl font-bold">Dev • Slides</h1>
+
+      <section className="space-y-2">
+        <p className="text-sm opacity-80">Server env seen by /api/dev/debug:</p>
+        <pre className="text-xs bg-black/5 p-3 rounded overflow-x-auto">{JSON.stringify(debug, null, 2)}</pre>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <input value={token} onChange={e=>setToken(e.target.value)} placeholder="Paste ADMIN_TOKEN or SEED_TOKEN" className="border rounded px-3 py-2 w-full" />
+          <button onClick={()=>seed('admin')} disabled={busy} className="px-3 py-2 rounded bg-black text-white">Seed (admin)</button>
+          <button onClick={()=>seed('seed')} disabled={busy} className="px-3 py-2 rounded border">Seed (seed)</button>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <button onClick={probePublic} className="px-3 py-1.5 rounded border">Probe public manifest</button>
+          <code className="opacity-70">{manifestURL || '(no URL)'}</code>
+          {probe && <span className={probe.ok ? 'text-green-600' : 'text-red-600'}>→ {probe.status}</span>}
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="font-semibold">Preview</h2>
+        {slides.length === 0 && <div className="text-sm opacity-70">No slides (fallback or manifest empty).</div>}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {slides.map((s:any, i:number) => (
+            <figure key={i} className="rounded-xl overflow-hidden border">
+              <img src={s.src} alt={s.alt || s.label || `slide-${i+1}`} className="w-full h-48 object-cover" />
+              {(s.label || s.alt) && <figcaption className="px-3 py-2 text-sm">{s.label || s.alt}</figcaption>}
+            </figure>
+          ))}
+        </div>
+      </section>
+    </div>
   );
 }

--- a/src/app/api/dev/slides/route.ts
+++ b/src/app/api/dev/slides/route.ts
@@ -1,0 +1,16 @@
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { loadSlides } from '@/lib/slides';
+
+export async function GET() {
+  if (process.env.NODE_ENV === 'production') {
+    return NextResponse.json({ error: 'Not available in production' }, { status: 404 });
+  }
+  try {
+    const data = await loadSlides();
+    return NextResponse.json({ ok: true, count: data.length, slides: data, host: process.env.NEXT_PUBLIC_SUPABASE_URL || null });
+  } catch (e:any) {
+    return NextResponse.json({ ok: false, error: e?.message || String(e) }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- Add locale-aware /dev/slides panel for seeding and previewing hero slides
- Harden /api/dev/seed-slides with token check and production guard
- Introduce /api/dev/slides endpoint to preview manifest or fallback slides
- Document slides dev panel usage in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint config)*
- `pkill -f "next dev" 2>/dev/null || true`
- `npm run -s dev:3001 & echo $! > .pid && sleep 6`
- `echo '--- debug ---' && curl -s http://localhost:3001/api/dev/debug`
- `echo '--- slides json ---' && curl -s http://localhost:3001/api/dev/slides | jq '.ok,.count' || true`
- `echo '--- seed (seed token) ---' && curl -s -X POST -H "x-seed-token: ${SEED_TOKEN:-dev-seed-ok}" http://localhost:3001/api/dev/seed-slides | jq '.' || true`
- `echo '--- probe public manifest ---' && curl -I "${NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/assets-public/home-slides/manifest.json" | head -n 5`
- `test -f .pid && kill $(cat .pid) 2>/dev/null || true; rm -f .pid`


------
https://chatgpt.com/codex/tasks/task_e_68c538f0a1cc832cb59f139dd8258f8e